### PR TITLE
Fix for missed time input fields and comments

### DIFF
--- a/content-purely-hr.js
+++ b/content-purely-hr.js
@@ -130,7 +130,7 @@
     const commentIcon = row.querySelector(selectors.dayCommentIcon);
     
     // Do not add a comment if there is already one
-    if (commentIcon.classList.contains(statusClasses.commentFilled) {
+    if (commentIcon.classList.contains(statusClasses.commentFilled)) {
       return;
     }
     

--- a/content-purely-hr.js
+++ b/content-purely-hr.js
@@ -17,7 +17,8 @@
     statusClasses = {
       timeInputEmpty: 'zero',
       commentFilled: 'fa-comment',
-      commentEmtpy: 'fa-comment-o'
+      commentEmtpy: 'fa-comment-o',
+      commentModalOpened: 'modal-open'
     };
 
   fmtApi.utils.setMessageProxy({
@@ -88,6 +89,7 @@
         await cb(row);
       } catch (err) {
         if (err.message.match(/timeout for wait/i)) {
+          await fmtApi.utils.wait(100);
           rows = itemsGetter();
           i--;
         }
@@ -106,7 +108,7 @@
     }
 
     // While the field is marked as not completed
-    fmtApi.utils.waitForIt(() => {
+    await fmtApi.utils.waitForIt(() => {
       elt.dispatchEvent(new Event('click', evtArgs));
       elt.dispatchEvent(new KeyboardEvent('keydown', {keyCode: 8, which: 8}));
       elt.value = value;
@@ -127,7 +129,7 @@
       return;
     }
 
-    const commentIcon = row.querySelector(selectors.dayCommentIcon);
+    let commentIcon = row.querySelector(selectors.dayCommentIcon);
     
     // Do not add a comment if there is already one
     if (commentIcon.classList.contains(statusClasses.commentFilled)) {
@@ -145,7 +147,11 @@
     document.querySelector(selectors.dayCommentField).value = value;
     document.querySelector(selectors.dayCommentSave).dispatchEvent(new Event('click', evtArgs));
 
-    return fmtApi.utils.waitForIt(() => document.querySelector(selectors.dayCommentField) === null);
+    // Wait for comment icon to turn dark and for the modal to close
+    return fmtApi.utils.waitForIt(() => {
+      return commentIcon.classList.contains(statusClasses.commentFilled) && 
+            !document.body.classList.contains(statusClasses.commentModalOpened);
+    });
   }
 
 })();

--- a/content-purely-hr.js
+++ b/content-purely-hr.js
@@ -17,7 +17,6 @@
     statusClasses = {
       timeInputEmpty: 'zero',
       commentFilled: 'fa-comment',
-      commentEmtpy: 'fa-comment-o',
       commentModalOpened: 'modal-open'
     };
 
@@ -98,12 +97,8 @@
   }
 
   async function setInputValue(elt, value) {
-    if (!value) {
-      return;
-    }
-    
-    // Do not modify if the input already contains data
-    if (elt.value.length != 0) {
+    // Do not modify if no value or the input already contains data
+    if (!value || elt.value.length !== 0) {
       return;
     }
 
@@ -129,13 +124,13 @@
       return;
     }
 
-    let commentIcon = row.querySelector(selectors.dayCommentIcon);
-    
+    const commentIcon = row.querySelector(selectors.dayCommentIcon);
+
     // Do not add a comment if there is already one
     if (commentIcon.classList.contains(statusClasses.commentFilled)) {
       return;
     }
-    
+
     commentIcon.dispatchEvent(new Event('click', evtArgs));
 
     // wait for field to be visible in the modal dialog
@@ -149,8 +144,8 @@
 
     // Wait for comment icon to turn dark and for the modal to close
     return fmtApi.utils.waitForIt(() => {
-      return commentIcon.classList.contains(statusClasses.commentFilled) && 
-            !document.body.classList.contains(statusClasses.commentModalOpened);
+      return commentIcon.classList.contains(statusClasses.commentFilled) &&
+        !document.body.classList.contains(statusClasses.commentModalOpened);
     });
   }
 

--- a/content-purely-hr.js
+++ b/content-purely-hr.js
@@ -94,12 +94,21 @@
     if (!value) {
       return;
     }
+    
+    // Do not modify if the input already contains data
+    if (elt.value.length != 0) {
+      return;
+    }
 
-    elt.dispatchEvent(new Event('click', evtArgs));
-    elt.dispatchEvent(new KeyboardEvent('keydown', {keyCode: 8, which: 8}));
-    elt.value = value;
-    elt.dispatchEvent(new Event('change', evtArgs));
-    elt.dispatchEvent(new KeyboardEvent('keydown', {keyCode: 27, which: 27}));
+    // While the field is marked as not completed
+    while (elt.classList.contains('zero')) {
+      elt.dispatchEvent(new Event('click', evtArgs));
+      elt.dispatchEvent(new KeyboardEvent('keydown', {keyCode: 8, which: 8}));
+      elt.value = value;
+      elt.dispatchEvent(new Event('change', evtArgs));
+      elt.dispatchEvent(new KeyboardEvent('keydown', {keyCode: 27, which: 27}));
+      fmtApi.utils.wait(100);
+    }
 
     // wait for time picker to be hidden
     return fmtApi.utils.waitForIt(() => {

--- a/content-purely-hr.js
+++ b/content-purely-hr.js
@@ -13,6 +13,11 @@
       dayCommentIcon: '.phr-set-comment-for-day',
       dayCommentField: '.modal-dialog #dailyCommentForm textarea.form-control',
       dayCommentSave: '.modal-dialog .modal-footer button.phr-confirm-btn'
+    },
+    statusClasses = {
+      timeInputEmpty: 'zero',
+      commentFilled: 'fa-comment',
+      commentEmtpy: 'fa-comment-o'
     };
 
   fmtApi.utils.setMessageProxy({
@@ -101,14 +106,14 @@
     }
 
     // While the field is marked as not completed
-    while (elt.classList.contains('zero')) {
+    fmtApi.utils.waitForIt(() => {
       elt.dispatchEvent(new Event('click', evtArgs));
       elt.dispatchEvent(new KeyboardEvent('keydown', {keyCode: 8, which: 8}));
       elt.value = value;
       elt.dispatchEvent(new Event('change', evtArgs));
       elt.dispatchEvent(new KeyboardEvent('keydown', {keyCode: 27, which: 27}));
-      fmtApi.utils.wait(100);
-    }
+      return !elt.classList.contains(statusClasses.timeInputEmpty);
+    });
 
     // wait for time picker to be hidden
     return fmtApi.utils.waitForIt(() => {
@@ -122,7 +127,14 @@
       return;
     }
 
-    row.querySelector(selectors.dayCommentIcon).dispatchEvent(new Event('click', evtArgs));
+    const commentIcon = row.querySelector(selectors.dayCommentIcon);
+    
+    // Do not add a comment if there is already one
+    if (commentIcon.classList.contains(statusClasses.commentFilled) {
+      return;
+    }
+    
+    commentIcon.dispatchEvent(new Event('click', evtArgs));
 
     // wait for field to be visible in the modal dialog
     await fmtApi.utils.waitForIt(() => {


### PR DESCRIPTION
The extension will now ignore the fields that are already populated and this allows for filling in timesheets with pre-existing/custom data.

The extension will now make sure that the time is correctly filled in for all the input fields.